### PR TITLE
gcloud: capture not authenticated error.

### DIFF
--- a/practipy/gcloud.py
+++ b/practipy/gcloud.py
@@ -25,7 +25,7 @@ class TransferEvent:
     target_path: str
 
 
-def catch_unathenticated(f):
+def catch_unauthenticated(f):
     def aux(*args, **kwargs):
         from google.auth.exceptions import RefreshError
         try:
@@ -42,7 +42,7 @@ def catch_unathenticated(f):
             raise e
     return aux
 
-@catch_unathenticated
+@catch_unauthenticated
 def download_folder(
     project: str,
     source_dir: str,
@@ -91,7 +91,7 @@ def download_folder(
             wait(futures)
 
 
-@catch_unathenticated
+@catch_unauthenticated
 def download_files(
     project: str,
     bucket: str,
@@ -135,7 +135,7 @@ def download_files(
     return [event.target_path for event in events]
 
 
-@catch_unathenticated
+@catch_unauthenticated
 def upload_folder(
     project: str,
     source_dir: Union[Path, str],
@@ -173,7 +173,7 @@ def upload_folder(
             wait(futures)
 
 
-@catch_unathenticated
+@catch_unauthenticated
 def upload_files(
     project: str,
     paths: Sequence[Union[Path, str]],

--- a/practipy/gcloud.py
+++ b/practipy/gcloud.py
@@ -39,6 +39,7 @@ def catch_unathenticated(f, *args, **kwargs):
                     cmd = "gcloud auth application-default login --no-launch-browser"
                     raise ValueError(f"Captured potentially known error: {e}. Please make sure that " 
                         f"you have authenticated your machine using '{cmd}' command")
+            raise e
     return aux
 
 @catch_unathenticated

--- a/practipy/gcloud.py
+++ b/practipy/gcloud.py
@@ -25,7 +25,7 @@ class TransferEvent:
     target_path: str
 
 
-def catch_unathenticated(f, *args, **kwargs):
+def catch_unathenticated(f):
     def aux(*args, **kwargs):
         from google.auth.exceptions import RefreshError
         try:


### PR DESCRIPTION
In case of non-authenticated request, instead of 

```
   raise exceptions.RefreshError(error_details, response_data)
google.auth.exceptions.RefreshError: ('invalid_grant: Bad Request', {'error': 'invalid_grant', 'error_description': 'Bad Request'})
```

that MR provides error message with a hint with potentially proper fix.