### PR TITLE
Make `download_file` require fewer permissions

### DIFF
--- a/practipy/gcloud.py
+++ b/practipy/gcloud.py
@@ -98,7 +98,7 @@ def download_folder(
 @catch_unauthenticated
 def download_files(
     project: str,
-    bucket: str,
+    bucket_name: str,
     gcs_paths: Sequence[str],
     download_dir: Union[Path, str],
     strip_prefix: str = "",
@@ -112,7 +112,7 @@ def download_files(
     Note: paths are relative to `gs://<bucket_name>`!.
     """
 
-    bucket = gcs.Client(project=project).get_bucket(bucket)
+    bucket = gcs.Client(project=project).bucket(bucket_name)
     blobs = [bucket.blob(gcs_path) for gcs_path in gcs_paths]
     download_dir = Path(download_dir)
 
@@ -158,7 +158,7 @@ def download_file(
     bucket_name = source_dir.parts[0]
     source_path = str(source_dir.relative_to(bucket_name))
 
-    bucket = gcs.Client(project=project).get_bucket(bucket_name)
+    bucket = gcs.Client(project=project).bucket(bucket_name)
     blob = bucket.get_blob(source_path)
     if blob is None:
         raise FileNotFoundError(gcs_path)


### PR DESCRIPTION
From internal PR: https://github.com/plumerai/benchmark-worker-infra/pull/16/files#r945639351

> `get_bucket` makes an HTTP request which requires `storage.buckets.get` permissions. These are only part of the "Storage Object Admin" role which also grants write permission :warning: . The normal "Storage Object Viewer" for read only access does not have `storage.buckets.get`. Switching from `get_bucket` to `bucket` as recommended in the docs fixes this as it doesn't do a HTTP request.

I've tested the function locally.