### PR TITLE
Make `upload_folder` require fewer permissions

### DIFF
--- a/practipy/gcloud.py
+++ b/practipy/gcloud.py
@@ -189,7 +189,7 @@ def upload_folder(
     bucket_name = target_dir.parts[0]
     target_dir = str(target_dir.relative_to(bucket_name))
 
-    bucket = gcs.Client(project=project).get_bucket(str(bucket_name))
+    bucket = gcs.Client(project=project).bucket(str(bucket_name))
 
     # Note: This will overwrite any blobs that already exist.
     def upload_file(file: Path) -> TransferEvent:
@@ -227,7 +227,7 @@ def upload_files(
     bucket_name = target_dir.parts[0]
     target_dir = str(target_dir.relative_to(bucket_name))
 
-    bucket = gcs.Client(project=project).get_bucket(str(bucket_name))
+    bucket = gcs.Client(project=project).bucket(str(bucket_name))
 
     # Note: This will overwrite any blobs that already exist.
     def upload_file(file: Path) -> TransferEvent:


### PR DESCRIPTION
Same as #31 but for the upload functions.